### PR TITLE
fix: Update Dockerfile paths in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
+          file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-multiarch.outputs.tags }}
@@ -109,7 +109,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.jetson-orin
+          file: ./docker/Dockerfile.jetson-orin
           platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-jetson-orin.outputs.tags }}
@@ -159,7 +159,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.jetson-thor
+          file: ./docker/Dockerfile.jetson-thor
           platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-jetson-thor.outputs.tags }}
@@ -209,7 +209,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.mac
+          file: ./docker/Dockerfile.mac
           platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-mac.outputs.tags }}


### PR DESCRIPTION
After PyPI restructuring, Dockerfiles are now in docker/ subdirectory. Update all workflow file paths to use ./docker/Dockerfile*