### PR TITLE
fix: Add --ignore-installed flag for Jetson Thor pip upgrade

### DIFF
--- a/docker/Dockerfile.jetson-thor
+++ b/docker/Dockerfile.jetson-thor
@@ -37,7 +37,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
 WORKDIR /app
 
 # Upgrade pip and build tools
-RUN pip install --no-cache-dir --break-system-packages --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip setuptools wheel
 
 # Copy package files first for better layer caching
 COPY pyproject.toml MANIFEST.in ./


### PR DESCRIPTION
Ubuntu 24.04 base image has wheel installed via Debian package manager without RECORD file, causing pip upgrade to fail. Use --ignore-installed to work around this issue.