### PR TITLE
FIX: Allow camera enumeration when default device is busy

### DIFF
--- a/src/live_vlm_webui/static/index.html
+++ b/src/live_vlm_webui/static/index.html
@@ -2587,20 +2587,28 @@ After commands, explain: obstacles detected, clearance margins, goal inference, 
 
         // Enumerate and list available cameras
         async function enumerateCameras() {
+            const cameraSelect = document.getElementById('cameraSelect');
+            cameraSelect.innerHTML = '';
+
+            let permissionError = null;
+
             try {
-                // Request permission first to get device labels
+                // Request permission first to get device labels.
+                // This can fail if the default camera is busy, but we can still
+                // fall back to enumerateDevices() and let the user pick another one.
                 const tempStream = await navigator.mediaDevices.getUserMedia({ video: true });
                 tempStream.getTracks().forEach(track => track.stop());
+            } catch (err) {
+                permissionError = err;
+                console.warn('Initial camera probe failed, falling back to device enumeration:', err);
+            }
 
-                // Now enumerate with labels
+            try {
                 const devices = await navigator.mediaDevices.enumerateDevices();
                 const videoDevices = devices.filter(device => device.kind === 'videoinput');
 
-                const cameraSelect = document.getElementById('cameraSelect');
-                cameraSelect.innerHTML = '';
-
                 if (videoDevices.length === 0) {
-                    cameraSelect.innerHTML = '<option value="">No cameras found</option>';
+                    cameraSelect.innerHTML = `<option value="">${permissionError ? 'No accessible cameras found' : 'No cameras found'}</option>`;
                     return;
                 }
 
@@ -2611,12 +2619,18 @@ After commands, explain: obstacles detected, clearance margins, goal inference, 
                     cameraSelect.appendChild(option);
                 });
 
-                // Select first camera by default
-                selectedCameraId = videoDevices[0].deviceId;
+                if (!selectedCameraId || !videoDevices.some(device => device.deviceId === selectedCameraId)) {
+                    selectedCameraId = videoDevices[0].deviceId;
+                    cameraSelect.value = selectedCameraId;
+                }
+
                 console.log(`Found ${videoDevices.length} camera(s)`);
+                if (permissionError) {
+                    console.warn('Camera labels or default access may be limited until camera permissions or device availability are fixed.');
+                }
             } catch (err) {
                 console.error('Error enumerating cameras:', err);
-                document.getElementById('cameraSelect').innerHTML = '<option value="">Error detecting cameras</option>';
+                cameraSelect.innerHTML = '<option value="">Error detecting cameras</option>';
             }
         }
 


### PR DESCRIPTION
## Summary
- keep camera enumeration working when the initial `getUserMedia({ video: true })` probe fails
- populate the camera dropdown from `enumerateDevices()` so users can select another available camera
- preserve the current selection when it is still present

## Problem
If the browser's default camera is already in use, the initial permission probe fails and the UI currently collapses the dropdown to `Error detecting cameras`. That prevents users from selecting another free camera even when one is available.

## Verification
- reproduced locally with one webcam busy in OBS and a second webcam available
- reloaded the UI and confirmed the second camera could be selected after this fallback change
- ran `git diff --check`
- `python3 -m pytest -q` could not be run in this environment because `pytest` is not installed