### PR TITLE
fix: wait for ICE gathering before sending webcam WebRTC offer

### DIFF
--- a/src/live_vlm_webui/static/index.html
+++ b/src/live_vlm_webui/static/index.html
@@ -4237,6 +4237,27 @@ After commands, explain: obstacles detected, clearance margins, goal inference, 
                 const offer = await peerConnection.createOffer();
                 await peerConnection.setLocalDescription(offer);
 
+                // Wait for ICE gathering to complete before sending offer
+                // so all browser ICE candidates are embedded in the SDP
+                await new Promise((resolve) => {
+                    if (peerConnection.iceGatheringState === 'complete') {
+                        resolve();
+                    } else {
+                        const checkState = () => {
+                            if (peerConnection.iceGatheringState === 'complete') {
+                                peerConnection.removeEventListener('icegatheringstatechange', checkState);
+                                resolve();
+                            }
+                        };
+                        peerConnection.addEventListener('icegatheringstatechange', checkState);
+                        setTimeout(() => {
+                            peerConnection.removeEventListener('icegatheringstatechange', checkState);
+                            console.warn('ICE gathering timeout - proceeding anyway');
+                            resolve();
+                        }, 5000);
+                    }
+                });
+
                 const response = await fetch('/offer', {
                     method: 'POST',
                     headers: {


### PR DESCRIPTION
## Summary

- Webcam mode was sending the WebRTC offer to the server immediately after `setLocalDescription`, before browser ICE gathering completed — so the offer SDP had no ICE candidates embedded, leaving the server with nothing to check connectivity against
- Adds the same ICE gathering wait (with a 5-second timeout fallback) that RTSP mode already had, ensuring all browser candidates are present in the SDP before it is sent
- Fixes the symptom where the connection would log "ICE connection state: checking" and "Connection state: connecting" indefinitely and never reach "connected"