### PR TITLE
fix(rtsp): prevent teardown crash and unbounded PTS drift

### DIFF
--- a/src/live_vlm_webui/rtsp_track.py
+++ b/src/live_vlm_webui/rtsp_track.py
@@ -10,11 +10,20 @@ SPDX-License-Identifier: Apache-2.0
 
 import av
 import asyncio
+import fractions
 import logging
 import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 from aiortc import VideoStreamTrack
 from av import VideoFrame
+
+# Wall-clock timestamp base used when the source does not provide a usable
+# presentation clock (see RTSPVideoTrack._restamp).
+VIDEO_CLOCK_RATE = 90000
+VIDEO_TIME_BASE = fractions.Fraction(1, VIDEO_CLOCK_RATE)
 
 # Suppress verbose ffmpeg/libav logging (HEVC decoder errors are normal for IP cameras)
 # These POC/slice errors happen due to network packet loss but stream recovers automatically
@@ -41,6 +50,7 @@ class RTSPVideoTrack(VideoStreamTrack):
         reconnect_attempts: int = 5,
         reconnect_delay: float = 2.0,
         options: Optional[dict] = None,
+        io_timeout: float = 10.0,
     ):
         """
         Initialize RTSP video track.
@@ -50,15 +60,32 @@ class RTSPVideoTrack(VideoStreamTrack):
             reconnect_attempts: Number of reconnection attempts on failure (default: 5)
             reconnect_delay: Base delay between reconnection attempts in seconds (default: 2.0)
             options: Additional PyAV container options (default: TCP transport)
+            io_timeout: Bound on blocking libav I/O in seconds (default: 10.0). Keeps a
+                stalled source from wedging the decode thread and, through it, stop().
         """
         super().__init__()
         self.rtsp_url = rtsp_url
         self.reconnect_attempts = reconnect_attempts
         self.reconnect_delay = reconnect_delay
+        self.io_timeout = io_timeout
         self.container: Optional[av.container.InputContainer] = None
         self.stream: Optional[av.video.VideoStream] = None
         self._stopped = False
         self._frame_count = 0
+
+        # Guards every access to self.container. Demuxing runs in a worker thread
+        # while stop()/_reconnect() run on the event loop, and closing a container
+        # that a thread is still demuxing frees libav memory out from under it
+        # (SIGSEGV/SIGBUS). Holding this lock makes close() wait for the worker.
+        self._container_lock = threading.Lock()
+
+        # Dedicated worker so a blocking demux cannot starve the shared default
+        # executor, and so shutdown is scoped to this track.
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rtsp-track")
+
+        # Wall-clock re-stamping state (see _restamp)
+        self._restamp_pts = False
+        self._start_time: Optional[float] = None
 
         # Default options for RTSP
         self.options = options or {
@@ -94,20 +121,42 @@ class RTSPVideoTrack(VideoStreamTrack):
         try:
             logger.info(f"Connecting to RTSP stream: {safe_url}")
 
-            # Open RTSP stream
-            self.container = av.open(self.rtsp_url, options=self.options)
+            # Open RTSP stream. The timeout bounds blocking I/O inside libav so a
+            # dead source cannot wedge the worker thread (and with it, stop()).
+            container = av.open(self.rtsp_url, options=self.options, timeout=self.io_timeout)
 
             # Get video stream
-            if not self.container.streams.video:
+            if not container.streams.video:
+                container.close()
                 raise ValueError("No video stream found in RTSP source")
 
-            self.stream = self.container.streams.video[0]
+            stream = container.streams.video[0]
 
             # Log stream information
-            codec = self.stream.codec_context.name
-            width = self.stream.width or "unknown"
-            height = self.stream.height or "unknown"
-            fps = self.stream.average_rate or "unknown"
+            codec = stream.codec_context.name
+            width = stream.width or "unknown"
+            height = stream.height or "unknown"
+            fps = stream.average_rate or "unknown"
+
+            # Containers that cannot report a frame rate (notably MJPEG over HTTP,
+            # which carries no timestamps on the wire) get a synthesized PTS clock
+            # from the demuxer - libav defaults to 25fps regardless of how fast
+            # frames actually arrive. Trusting that clock makes downstream latency
+            # math drift without bound, so re-stamp those sources instead.
+            restamp = stream.average_rate is None
+
+            # Publish to the decode thread only once fully initialized
+            with self._container_lock:
+                self.container = container
+                self.stream = stream
+                self._restamp_pts = restamp
+                self._start_time = None
+
+            if restamp:
+                logger.info(
+                    "Source reports no frame rate; re-stamping frames with wall-clock PTS "
+                    "(demuxer timestamps would be synthesized and drift)"
+                )
 
             logger.info(f"RTSP connected successfully: {codec} {width}x{height} @{fps}fps")
 
@@ -134,14 +183,14 @@ class RTSPVideoTrack(VideoStreamTrack):
         try:
             # Read frame from container (blocking operation, run in executor)
             loop = asyncio.get_event_loop()
-            frame = await loop.run_in_executor(None, self._read_frame)
+            frame = await loop.run_in_executor(self._executor, self._read_frame)
 
             if frame is None:
                 if not self._stopped:
                     logger.warning("RTSP stream ended unexpectedly, attempting reconnection")
                     await self._reconnect()
                     # Try again after reconnection
-                    frame = await loop.run_in_executor(None, self._read_frame)
+                    frame = await loop.run_in_executor(self._executor, self._read_frame)
                     if frame is None:
                         raise StopAsyncIteration
                 else:
@@ -153,7 +202,7 @@ class RTSPVideoTrack(VideoStreamTrack):
             if self._frame_count % 300 == 0:  # Every ~10 seconds at 30fps
                 logger.debug(f"RTSP: Received {self._frame_count} frames")
 
-            return frame
+            return self._restamp(frame)
 
         except StopAsyncIteration:
             raise
@@ -164,36 +213,67 @@ class RTSPVideoTrack(VideoStreamTrack):
                 await self._reconnect()
             raise
 
+    def _restamp(self, frame: VideoFrame) -> VideoFrame:
+        """
+        Give the frame a wall-clock presentation timestamp when the source has none.
+
+        MJPEG-over-HTTP (and any other container without timestamps on the wire)
+        gets a demuxer-synthesized 25fps PTS clock that is unrelated to how fast
+        frames really arrive. Downstream latency tracking treats PTS as a
+        wall-clock-anchored timeline, so a source running at any other rate drifts
+        further behind on every frame. Re-stamping from a monotonic clock keeps
+        that math honest; sources with a real clock are left untouched.
+        """
+        if not self._restamp_pts:
+            return frame
+
+        now = time.monotonic()
+        if self._start_time is None:
+            self._start_time = now
+
+        frame.pts = int((now - self._start_time) * VIDEO_CLOCK_RATE)
+        frame.time_base = VIDEO_TIME_BASE
+        return frame
+
     def _read_frame(self) -> Optional[VideoFrame]:
         """
         Read and decode next frame from RTSP stream (blocking).
 
-        This is a blocking operation and should be run in an executor.
+        This is a blocking operation and should be run in an executor. The
+        container lock is held for the whole demux/decode so that stop() and
+        _reconnect() cannot close the container underneath us.
 
         Returns:
             VideoFrame or None if stream ended or error occurred
         """
-        if not self.container or not self.stream:
-            logger.error("Cannot read frame: container or stream not initialized")
-            return None
+        with self._container_lock:
+            if self._stopped:
+                return None
 
-        try:
-            # Demux and decode packets until we get a video frame
-            for packet in self.container.demux(self.stream):
-                for frame in packet.decode():
-                    if isinstance(frame, VideoFrame):
-                        return frame
+            if not self.container or not self.stream:
+                logger.error("Cannot read frame: container or stream not initialized")
+                return None
 
-            # No more frames available (stream ended)
-            logger.info("RTSP stream reached end of file")
-            return None
+            try:
+                # Demux and decode packets until we get a video frame
+                for packet in self.container.demux(self.stream):
+                    # Bail out promptly when stop() is waiting on the lock
+                    if self._stopped:
+                        return None
+                    for frame in packet.decode():
+                        if isinstance(frame, VideoFrame):
+                            return frame
 
-        except av.error.EOFError:
-            logger.warning("RTSP stream EOF")
-            return None
-        except Exception as e:
-            logger.error(f"Error decoding RTSP frame: {e}")
-            return None
+                # No more frames available (stream ended)
+                logger.info("RTSP stream reached end of file")
+                return None
+
+            except av.error.EOFError:
+                logger.warning("RTSP stream EOF")
+                return None
+            except Exception as e:
+                logger.error(f"Error decoding RTSP frame: {e}")
+                return None
 
     async def _reconnect(self):
         """
@@ -204,14 +284,18 @@ class RTSPVideoTrack(VideoStreamTrack):
         safe_url = self._sanitize_url(self.rtsp_url)
         logger.info(f"Attempting RTSP reconnection to {safe_url}...")
 
-        # Clean up existing connection
-        if self.container:
-            try:
-                self.container.close()
-            except Exception as e:
-                logger.debug(f"Error closing container during reconnect: {e}")
-            self.container = None
-            self.stream = None
+        # Clean up existing connection. Take the container lock so we never close
+        # while the decode thread is inside demux().
+        with self._container_lock:
+            if self.container:
+                try:
+                    self.container.close()
+                except Exception as e:
+                    logger.debug(f"Error closing container during reconnect: {e}")
+                self.container = None
+                self.stream = None
+            # A fresh connection restarts the wall-clock timeline
+            self._start_time = None
 
         # Try to reconnect with exponential backoff
         for attempt in range(self.reconnect_attempts):
@@ -242,18 +326,30 @@ class RTSPVideoTrack(VideoStreamTrack):
         Stop the RTSP stream and clean up resources.
 
         Should be called when stream is no longer needed.
+
+        Cancelling the asyncio task that awaits recv() does NOT stop the executor
+        thread running _read_frame; it stays blocked inside libav's demux(). Closing
+        the container from here while that is happening frees memory the thread is
+        still reading, which crashes the whole process (SIGSEGV/SIGBUS). Setting
+        _stopped first and then taking the container lock makes this wait for the
+        decode thread to leave demux() before anything is freed.
         """
         self._stopped = True
 
-        if self.container:
-            try:
-                self.container.close()
-                logger.info(f"RTSP stream closed: {self._frame_count} frames received")
-            except Exception as e:
-                logger.warning(f"Error closing RTSP container: {e}")
-            finally:
-                self.container = None
-                self.stream = None
+        with self._container_lock:
+            if self.container:
+                try:
+                    self.container.close()
+                    logger.info(f"RTSP stream closed: {self._frame_count} frames received")
+                except Exception as e:
+                    logger.warning(f"Error closing RTSP container: {e}")
+                finally:
+                    self.container = None
+                    self.stream = None
+
+        # Release the worker thread. Not waited on: the lock above already
+        # guarantees no thread is touching the container anymore.
+        self._executor.shutdown(wait=False)
 
         super().stop()
 

--- a/src/live_vlm_webui/video_processor.py
+++ b/src/live_vlm_webui/video_processor.py
@@ -61,6 +61,13 @@ class VideoProcessorTrack(VideoStreamTrack):
         self.first_frame_time = None  # Wall clock time of first frame
         self.frame_time_base = None  # Time base for PTS conversion (e.g., 1/90000)
 
+    def _reset_timing(self, frame):
+        """Re-anchor the latency baseline to the given frame."""
+        if frame.pts is not None:
+            self.first_frame_pts = frame.pts
+            self.first_frame_time = time.time()
+            self.frame_time_base = float(frame.time_base)
+
     async def recv(self):
         """
         Receive frame from input track, process it, and return with text overlay
@@ -98,6 +105,7 @@ class VideoProcessorTrack(VideoStreamTrack):
 
                 # Drop frames until we get a fresh one
                 dropped_count = 0
+                latency_before_drop = frame_latency
                 while frame_latency > max_latency:
                     self.dropped_frames += 1
                     dropped_count += 1
@@ -116,15 +124,26 @@ class VideoProcessorTrack(VideoStreamTrack):
                         # If PTS becomes unavailable, stop dropping frames
                         break
 
+                    # Dropping only reclaims latency when the source clock advances at
+                    # least as fast as wall clock. If it does not, each dropped frame
+                    # costs more wall time than it recovers and the loop makes things
+                    # worse - re-anchor the timeline instead of draining the stream.
+                    if dropped_count >= 10 and frame_latency >= latency_before_drop:
+                        logger.warning(
+                            f"Dropping is not reducing latency "
+                            f"({latency_before_drop:.2f}s -> {frame_latency:.2f}s after "
+                            f"{dropped_count} frames); source clock does not track wall "
+                            f"clock. Re-anchoring timing."
+                        )
+                        self._reset_timing(frame)
+                        break
+
                     # Prevent infinite loop
                     if dropped_count > 100:
                         logger.error(
                             f"Dropped {dropped_count} frames, but still behind. Resetting timing."
                         )
-                        if frame.pts is not None:
-                            self.first_frame_pts = frame.pts
-                            self.first_frame_time = time.time()
-                            self.frame_time_base = float(frame.time_base)
+                        self._reset_timing(frame)
                         break
 
                 if dropped_count > 0:

--- a/tests/unit/test_rtsp_track.py
+++ b/tests/unit/test_rtsp_track.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for RTSPVideoTrack teardown safety and PTS re-stamping.
+
+Covers two regressions:
+
+1. Closing the PyAV container while the decode thread is still inside demux()
+   frees libav memory out from under that thread and crashes the process.
+   stop() must wait for the decode thread to leave the container.
+
+2. Sources without timestamps on the wire (MJPEG over HTTP) get a demuxer
+   synthesized PTS clock that ignores the real arrival rate. Those frames must
+   be re-stamped from a wall clock or downstream latency math drifts forever.
+"""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from live_vlm_webui.rtsp_track import VIDEO_CLOCK_RATE, RTSPVideoTrack
+
+
+class FakeStream:
+    """Stand-in for av.video.VideoStream."""
+
+    def __init__(self, average_rate=None):
+        self.average_rate = average_rate
+        self.width = 640
+        self.height = 480
+        self.codec_context = type("Ctx", (), {"name": "mjpeg"})()
+        self.time_base = None
+
+
+class FakeStreams:
+    def __init__(self, stream):
+        self.video = [stream]
+
+
+class FakeContainer:
+    """
+    Minimal av.container.InputContainer stand-in.
+
+    demux() blocks on `release` so a test can hold the decode thread inside the
+    container exactly the way a real blocking network read does.
+    """
+
+    def __init__(self, stream, release=None):
+        self.streams = FakeStreams(stream)
+        self.closed = False
+        self.closed_at = None
+        self.demux_exited_at = None
+        self._release = release
+
+    def demux(self, stream):
+        if self._release is not None:
+            self._release.wait(timeout=5)
+        self.demux_exited_at = time.monotonic()
+        return iter([])
+
+    def close(self):
+        self.closed = True
+        self.closed_at = time.monotonic()
+
+
+class FakeFrame:
+    def __init__(self, pts=1000, time_base="1/25"):
+        self.pts = pts
+        self.time_base = time_base
+
+
+def make_track(container):
+    """Build a track against a fake container, bypassing real network I/O."""
+    with patch("av.open", return_value=container):
+        return RTSPVideoTrack("rtsp://fake/stream")
+
+
+class TestTeardownSafety:
+    """stop() must not free the container while the decode thread is using it."""
+
+    def test_stop_waits_for_decode_thread(self):
+        release = threading.Event()
+        stream = FakeStream(average_rate=30)
+        container = FakeContainer(stream, release=release)
+        track = make_track(container)
+
+        # Decode thread enters demux() and stays there
+        reader_done = threading.Event()
+
+        def reader():
+            track._read_frame()
+            reader_done.set()
+
+        t = threading.Thread(target=reader)
+        t.start()
+        time.sleep(0.2)  # let the reader get inside demux()
+        assert not container.closed, "container closed before decode thread started"
+
+        # stop() from the "event loop" side while the reader is still inside
+        release.set()
+        track.stop()
+        t.join(timeout=5)
+
+        assert reader_done.is_set(), "decode thread never finished"
+        assert container.closed, "stop() did not close the container"
+        # The crash was close() landing while demux() was still running
+        assert container.demux_exited_at is not None
+        assert container.closed_at >= container.demux_exited_at, (
+            "container was closed before the decode thread left demux() - "
+            "this is the use-after-free"
+        )
+
+    def test_stop_is_idempotent(self):
+        container = FakeContainer(FakeStream(average_rate=30))
+        track = make_track(container)
+        track.stop()
+        track.stop()
+        assert container.closed
+
+    def test_read_frame_returns_none_after_stop(self):
+        container = FakeContainer(FakeStream(average_rate=30))
+        track = make_track(container)
+        track.stop()
+        assert track._read_frame() is None
+
+
+class TestPtsRestamping:
+    """Sources with no usable clock get wall-clock PTS; others are left alone."""
+
+    def test_restamp_enabled_when_source_reports_no_rate(self):
+        container = FakeContainer(FakeStream(average_rate=None))
+        track = make_track(container)
+        assert track._restamp_pts is True
+
+    def test_restamp_disabled_when_source_reports_rate(self):
+        container = FakeContainer(FakeStream(average_rate=30))
+        track = make_track(container)
+        assert track._restamp_pts is False
+
+    def test_frames_untouched_when_source_has_clock(self):
+        container = FakeContainer(FakeStream(average_rate=30))
+        track = make_track(container)
+        frame = FakeFrame(pts=4242, time_base="1/25")
+        out = track._restamp(frame)
+        assert out.pts == 4242
+        assert out.time_base == "1/25"
+
+    def test_restamped_pts_tracks_wall_clock(self):
+        """
+        The regression: a 25fps synthesized clock on a 10fps source made PTS
+        advance 0.04s per frame while 0.1s of wall time passed, so the computed
+        latency grew ~0.6s for every second of streaming. Re-stamped PTS must
+        stay locked to wall clock instead.
+        """
+        container = FakeContainer(FakeStream(average_rate=None))
+        track = make_track(container)
+
+        first = track._restamp(FakeFrame())
+        assert first.pts == 0
+
+        time.sleep(0.3)
+        second = track._restamp(FakeFrame())
+
+        elapsed_from_pts = (second.pts - first.pts) / VIDEO_CLOCK_RATE
+        assert elapsed_from_pts == pytest.approx(
+            0.3, abs=0.15
+        ), f"re-stamped PTS advanced {elapsed_from_pts:.3f}s over ~0.3s of wall time"
+        assert second.time_base.denominator == VIDEO_CLOCK_RATE
+
+    def test_restamp_timeline_resets_on_reconnect(self):
+        container = FakeContainer(FakeStream(average_rate=None))
+        track = make_track(container)
+        track._restamp(FakeFrame())
+        assert track._start_time is not None
+
+        # A fresh connection must re-anchor the timeline
+        with patch("av.open", return_value=FakeContainer(FakeStream(average_rate=None))):
+            track._connect()
+        assert track._start_time is None


### PR DESCRIPTION
Two defects in the RTSP input path, found while feeding it an MJPEG-over-HTTP
source. Both also affect the shipped RTSP IP camera feature.

## 1. Use-after-free on stream teardown — crashes the whole server process

`_read_frame()` runs in an executor thread and blocks inside
`container.demux()`. Cancelling the asyncio task that awaits `recv()` does not
stop that thread, so the `container.close()` that follows frees libav memory
while the thread is still reading it.

```
Fatal Python error: Segmentation fault

Current thread 0x0000ffff4a09f180 (most recent call first):
  File "live_vlm_webui/rtsp_track.py", line 182 in _read_frame
  File "concurrent/futures/thread.py", line 58 in run
  File "concurrent/futures/thread.py", line 92 in _worker
```

The signal varied between runs (SIGSEGV and SIGBUS), which is typical of a
use-after-free. This kills the server process, so every other session dies with
it. Reproduced on 3 of 3 unpatched runs, usually within two start/stop cycles.

**Fix:** guard all container access with a lock so `stop()` and `_reconnect()`
wait for the decode thread to leave `demux()` before closing. Supporting
changes:

- check `_stopped` inside the demux loop so that wait stays short
- bound blocking libav I/O with a timeout (`io_timeout`, default 10s) so a dead
  source cannot wedge teardown indefinitely
- give each track its own single-thread executor instead of the shared default
  one, so a blocked demux cannot starve unrelated work

## 2. Synthesized PTS clock drifts without bound

Containers that carry no timestamps on the wire — MJPEG over HTTP being the
common case — get a demuxer-synthesized PTS clock. libav defaults it to 25fps
regardless of how fast frames actually arrive. `VideoProcessorTrack` treats PTS
as a wall-clock-anchored timeline, so a 10fps source accumulates roughly 0.6s of
apparent latency for every second of streaming, without limit:

```
n= 10 wall=  0.84s pts_time=  0.36s  drift= +0.48s
n= 20 wall=  1.79s pts_time=  0.76s  drift= +1.03s
n= 30 wall=  2.75s pts_time=  1.16s  drift= +1.59s
n= 40 wall=  3.70s pts_time=  1.56s  drift= +2.14s
```

Harmless at the default `max_frame_latency` of 0. Enabling the latency threshold
makes the drop loop fire continuously — it discards 101 frames (~10s at 10fps),
ends up *further* behind than when it started, re-anchors, and repeats:

```
Frame is 2.05s behind, dropping frames (threshold: 2.0s)
Dropped 101 frames, but still behind. Resetting timing.
Dropped 101 frames, now at 7.79s latency
Frame is 2.05s behind, dropping frames          <- 3.4s later
Dropped 101 frames, but still behind. Resetting timing.
Dropped 101 frames, now at 8.11s latency
```

Roughly 74% of wall time is spent discarding frames. Measured 3.5x throughput
loss (7 VLM responses -> 2 over 40s).

**Fix:** re-stamp frames from a monotonic clock when the source reports no frame
rate. Sources with a real clock are left untouched. Also bail out of the drop
loop after 10 frames when dropping is not reducing latency, instead of draining
101 frames first — that keeps the failure bounded for any other source whose
clock does not track wall time.

## Verification

Tested on Jetson Orin Nano (JetPack 6, aarch64) against Ollama `gemma3:4b`,
using an emulated ESP32-P4 style MJPEG source (multipart/x-mixed-replace,
640x480 @10fps). All numbers below come from a clean checkout of this branch.

| | before | after |
|---|---|---|
| teardown start/stop cycles | crash within ~2 | 12/12 clean |
| drop cycles (threshold 2.0s, 40s) | 3 | 0 |
| VLM responses with threshold on | 2 | 4 (matches threshold-off baseline) |
| unit + integration tests | 11 passed | 19 passed |

**No regression for sources with a real clock.** Re-ran the whole path against
an H.264/MPEG-TS source, which is what an RTSP camera looks like to PyAV:

```
codec=h264  average_rate=10  time_base=1/90000
-> re-stamping not applied, frames pass through unchanged
```

Frames flowed at the reported rate, VLM responded, teardown was clean, and no
re-stamping log was emitted.

## Tests

Adds `tests/unit/test_rtsp_track.py` (8 tests) covering teardown ordering and
PTS re-stamping. These are real regression tests — removing just the lock from
`stop()` fails the teardown test:

```
AssertionError: container was closed before the decode thread left demux()
                - this is the use-after-free
```

## Notes for reviewers

- The re-stamp trigger is a heuristic (`stream.average_rate is None`). It is
  reliable for MJPEG/HTTP but would miss a source that reports a rate while its
  clock is inaccurate. The early exit from the drop loop is the safety net for
  that case.
- `io_timeout` defaults to 10s. This is a behavior change: a source that stalls
  longer than that now triggers reconnection where it previously blocked
  forever. Happy to raise the default or make it opt-in.
- `stop()` briefly blocks the event loop while waiting for the container lock —
  normally one packet, bounded by `io_timeout`. An async teardown path would
  avoid this but would change the `MediaStreamTrack.stop()` signature.
- Happy to split this into two commits if you would prefer to review the fixes
  separately.
