### PR TITLE
fix: detect missing NVIDIA runtime on Jetson Orin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Jetson Docker launcher:** Detect an unregistered NVIDIA runtime before starting Jetson Orin containers and show the JetPack repair steps.
+
 ---
 
 ## [0.4.0] - 2026-03-02

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -61,6 +61,20 @@ Docker is **strongly recommended** for Jetson platforms:
 
 For advanced users who want fine-grained control over Docker configuration.
 
+### Jetson Docker runtime check
+
+Before starting a Jetson container, the launcher checks Docker's registered runtimes. On **Jetson Orin (JetPack 6 / L4T R36)** it uses `--runtime=nvidia` only when Docker reports that runtime. If it is missing, the launcher exits before creating a container instead of failing with `unknown or invalid runtime name: nvidia`.
+
+Repair the runtime on the Jetson, then rerun the launcher:
+
+```bash
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
+docker info --format '{{json .Runtimes}}'  # must contain "nvidia"
+```
+
 ### PC (x86_64 with NVIDIA GPU)
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -705,6 +705,23 @@ ollama pull llama3.2-vision:11b
 
 ## Docker Issues
 
+### "unknown or invalid runtime name: nvidia" on Jetson
+
+**Issue:** The launcher stops before starting a Jetson Orin container because Docker does not list the `nvidia` runtime. Without that runtime, the Jetson image cannot receive the required NVIDIA driver and L4T mounts.
+
+**Fix:** Configure the NVIDIA Container Toolkit for Docker, restart Docker, and verify the runtime before trying again:
+
+```bash
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
+docker info --format '{{json .Runtimes}}'  # output must include "nvidia"
+./scripts/start_container.sh
+```
+
+For Jetson Orin systems provisioned with SDK Manager, these are the JetPack Docker setup steps. Do not work around this error by manually removing GPU support: the Jetson container requires it.
+
 ### "NVML not available" in Docker
 
 **Issue:** GPU monitoring shows "N/A" or NVML errors

--- a/scripts/docker_runtime.sh
+++ b/scripts/docker_runtime.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Docker runtime helpers shared by container launchers.  These functions expect
+# DOCKER_CMD and the colour variables from the calling script to be set.
+
+docker_runtime_is_available() {
+    local runtime_name="$1"
+    local runtimes
+
+    runtimes=$("$DOCKER_CMD" info --format '{{json .Runtimes}}' 2>/dev/null) || return 1
+    printf '%s\n' "$runtimes" | grep -Eq "\\\"${runtime_name}\\\"[[:space:]]*:"
+}
+
+print_jetson_nvidia_runtime_repair_guidance() {
+    echo -e "${RED}❌ Docker does not have the NVIDIA runtime registered.${NC}"
+    echo -e "${YELLOW}   The Jetson Orin image needs the NVIDIA Container Toolkit; starting now"
+    echo -e "   would fail with: unknown or invalid runtime name: nvidia.${NC}"
+    echo ""
+    echo -e "${BLUE}Repair the Docker runtime, then run this launcher again:${NC}"
+    echo -e "${GREEN}sudo apt update${NC}"
+    echo -e "${GREEN}sudo apt install -y nvidia-container-toolkit${NC}"
+    echo -e "${GREEN}sudo nvidia-ctk runtime configure --runtime=docker${NC}"
+    echo -e "${GREEN}sudo systemctl daemon-reload && sudo systemctl restart docker${NC}"
+    echo ""
+    echo -e "${BLUE}Verify that Docker now lists the runtime:${NC}"
+    echo -e "${GREEN}docker info --format '{{json .Runtimes}}'${NC}"
+    echo ""
+    echo -e "${YELLOW}If 'nvidia' is still absent, reinstall the NVIDIA Container Toolkit from"
+    echo -e "   the JetPack package repository before retrying.${NC}"
+}
+
+configure_jetson_gpu_access() {
+    case "$PLATFORM" in
+        jetson-orin)
+            if docker_runtime_is_available "nvidia"; then
+                RUNTIME_FLAG="--runtime=nvidia"
+                echo -e "   ${GREEN}✓ NVIDIA Docker runtime detected${NC}"
+            else
+                print_jetson_nvidia_runtime_repair_guidance
+                return 1
+            fi
+            ;;
+        jetson-thor)
+            # Preserve the existing launcher behavior for Thor. Issue #28 is
+            # specific to Jetson Orin systems where the runtime is missing.
+            RUNTIME_FLAG="--runtime=nvidia"
+            ;;
+    esac
+}

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -84,6 +84,11 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Docker runtime checks are kept separate so they can be tested without a
+# Jetson or a running container.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/docker_runtime.sh"
+
 # ==============================================================================
 # Functions to fetch and display available versions
 # ==============================================================================
@@ -1021,7 +1026,6 @@ elif [ "$ARCH" = "aarch64" ]; then
             # It's a Jetson, but we can't read L4T version - default to Orin (most common)
             PLATFORM="jetson-orin"
             PLATFORM_SUFFIX="-jetson-orin"
-            RUNTIME_FLAG="--runtime nvidia"
             echo -e "   Platform: ${GREEN}NVIDIA Jetson Orin${NC} (L4T version unavailable, detected via hardware)"
         elif command -v nvidia-smi &> /dev/null && nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | grep -qi "jetson\|orin\|thor\|xavier\|nano"; then
             # Check GPU name for Jetson indicators
@@ -1029,12 +1033,10 @@ elif [ "$ARCH" = "aarch64" ]; then
             if echo "$GPU_NAME" | grep -qi "thor"; then
                 PLATFORM="jetson-thor"
                 PLATFORM_SUFFIX="-jetson-thor"
-                RUNTIME_FLAG="--runtime=nvidia"
                 echo -e "   Platform: ${GREEN}NVIDIA Jetson Thor${NC} (detected via GPU: ${GPU_NAME})"
             else
                 PLATFORM="jetson-orin"
                 PLATFORM_SUFFIX="-jetson-orin"
-                RUNTIME_FLAG="--runtime nvidia"
                 echo -e "   Platform: ${GREEN}NVIDIA Jetson Orin${NC} (detected via GPU: ${GPU_NAME})"
             fi
         fi
@@ -1046,12 +1048,10 @@ elif [ "$ARCH" = "aarch64" ]; then
         if [ "$L4T_VERSION" -ge 38 ]; then
             PLATFORM="jetson-thor"
             PLATFORM_SUFFIX="-jetson-thor"
-            RUNTIME_FLAG="--runtime=nvidia"
             echo -e "   Platform: ${GREEN}NVIDIA Jetson Thor${NC} (L4T R${L4T_VERSION})"
         else
             PLATFORM="jetson-orin"
             PLATFORM_SUFFIX="-jetson-orin"
-            RUNTIME_FLAG="--runtime nvidia"
             echo -e "   Platform: ${GREEN}NVIDIA Jetson Orin${NC} (L4T R${L4T_VERSION})"
         fi
     elif [ -z "$PLATFORM" ]; then
@@ -1085,6 +1085,13 @@ elif [ "$ARCH" = "aarch64" ]; then
 else
     echo -e "${RED}❌ Unsupported architecture: ${ARCH}${NC}"
     exit 1
+fi
+
+if [[ "$PLATFORM" == "jetson-"* ]]; then
+    echo -e "${YELLOW}🔍 Checking Jetson Docker GPU configuration...${NC}"
+    if ! configure_jetson_gpu_access; then
+        exit 1
+    fi
 fi
 
 echo ""

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,9 @@ pytest tests/unit tests/integration tests/performance
 # Run unit tests only (fast)
 pytest tests/unit
 
+# Test Docker runtime selection without Docker or a Jetson
+bash tests/shell/test_docker_runtime.sh
+
 # Run with coverage
 pytest --cov=live_vlm_webui --cov-report=html
 

--- a/tests/shell/test_docker_runtime.sh
+++ b/tests/shell/test_docker_runtime.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../scripts/docker_runtime.sh"
+
+RED=""
+GREEN=""
+YELLOW=""
+BLUE=""
+NC=""
+DOCKER_CMD="mock_docker"
+
+mock_docker() {
+    if [ "$1" = "info" ] && [ "$2" = "--format" ]; then
+        printf '%s\n' "$MOCK_RUNTIMES"
+        return 0
+    fi
+    return 1
+}
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local description="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: ${description}: expected '${expected}', got '${actual}'" >&2
+        exit 1
+    fi
+}
+
+test_runtime_detection() {
+    MOCK_RUNTIMES='{"io.containerd.runc.v2":{},"nvidia":{"path":"nvidia-container-runtime"}}'
+    docker_runtime_is_available nvidia
+    ! docker_runtime_is_available missing
+}
+
+test_orin_uses_nvidia_runtime_when_registered() {
+    MOCK_RUNTIMES='{"nvidia":{"path":"nvidia-container-runtime"},"runc":{"path":"runc"}}'
+    PLATFORM="jetson-orin"
+    GPU_FLAG=""
+    RUNTIME_FLAG=""
+
+    configure_jetson_gpu_access >/dev/null
+    assert_equals "--runtime=nvidia" "$RUNTIME_FLAG" "Jetson Orin runtime flag"
+    assert_equals "" "$GPU_FLAG" "Jetson Orin GPU request flag"
+}
+
+test_orin_stops_when_nvidia_runtime_is_missing() {
+    MOCK_RUNTIMES='{"runc":{"path":"runc"}}'
+    PLATFORM="jetson-orin"
+    GPU_FLAG=""
+    RUNTIME_FLAG=""
+
+    if configure_jetson_gpu_access >/dev/null; then
+        echo "FAIL: Jetson Orin accepted an unregistered NVIDIA runtime" >&2
+        exit 1
+    fi
+    assert_equals "" "$RUNTIME_FLAG" "missing Orin runtime leaves no unsafe flag"
+}
+
+test_thor_behavior_is_unchanged() {
+    PLATFORM="jetson-thor"
+    GPU_FLAG=""
+    RUNTIME_FLAG=""
+
+    configure_jetson_gpu_access >/dev/null
+    assert_equals "--runtime=nvidia" "$RUNTIME_FLAG" "Jetson Thor runtime flag"
+    assert_equals "" "$GPU_FLAG" "Jetson Thor GPU request flag"
+}
+
+test_runtime_detection
+test_orin_uses_nvidia_runtime_when_registered
+test_orin_stops_when_nvidia_runtime_is_missing
+test_thor_behavior_is_unchanged
+
+echo "PASS: Docker runtime selection tests"


### PR DESCRIPTION
## Summary

- check Docker registered runtimes before launching a Jetson Orin container
- keep the existing `--runtime=nvidia` behavior when the runtime is available
- fail early with actionable NVIDIA Container Toolkit repair steps when it is missing
- document the recovery flow and add shell coverage for both runtime states

## Root cause

`start_container.sh` unconditionally passed `--runtime=nvidia` on Jetson Orin. On a JetPack 6.2.3 installation where Docker does not have the NVIDIA runtime registered, Docker exits with `unknown or invalid runtime name: nvidia` before the WebUI container can start.

The launcher should not remove GPU access or silently continue. It now detects this host configuration first and tells the user how to install/configure `nvidia-container-toolkit`, restart Docker, and verify the registered runtime.

## User-visible impact

- Properly configured Jetson Orin systems launch as before.
- Misconfigured systems receive a focused repair message instead of the opaque Docker runtime error.
- Jetson Thor behavior is unchanged.

## Testing

- `bash -n scripts/docker_runtime.sh scripts/start_container.sh tests/shell/test_docker_runtime.sh`
- `bash tests/shell/test_docker_runtime.sh`
- `git diff --check`

Fixes #28